### PR TITLE
fix(vm): harden against fuzzer-found crashes and hangs

### DIFF
--- a/compiler/src/modules/vm/builtins/async_ops.rs
+++ b/compiler/src/modules/vm/builtins/async_ops.rs
@@ -16,8 +16,8 @@ impl<'a> VM<'a> {
                 return Err(cold_type("not a coroutine"));
             };
 
-        // Bound coroutine depth; charge per-resume clone work.
-        if sync_frames.len() >= self.max_calls {
+        // Bound depth: sync frames within a coroutine, plus nested resumes from mutual awaits (native-stack recursion).
+        if sync_frames.len() >= self.max_calls || self.depth >= self.max_calls {
             return Err(cold_depth());
         }
         // Charge the whole cloned state (stack/slots/iters/frames), not just frame count.

--- a/compiler/src/modules/vm/builtins/sequence.rs
+++ b/compiler/src/modules/vm/builtins/sequence.rs
@@ -132,9 +132,8 @@ impl<'a> VM<'a> {
             self.exec_call(1, chunk, slots)?;
             keys.push(self.pop()?);
         }
-        let mut indices: Vec<usize> = (0..items.len()).collect();
         let mut sort_err: Option<VmErr> = None;
-        indices.sort_by(|&a, &b| {
+        let order = Self::stable_sort_indices(items.len(), |a, b| {
             if sort_err.is_some() { return core::cmp::Ordering::Equal; }
             match self.lt_vals(keys[a], keys[b]) {
                 Ok(true) => core::cmp::Ordering::Less,
@@ -147,17 +146,18 @@ impl<'a> VM<'a> {
             }
         });
         if let Some(e) = sort_err { return Err(e); }
-        Ok(indices.into_iter().map(|i| items[i]).collect())
+        Ok(order.into_iter().map(|i| items[i]).collect())
     }
 
-    /* In-place sort via `lt_vals`. Stashes the first error and surfaces it after the sort, `sort_by` closures can't return Result. */
+    /* In-place sort via `lt_vals`. Stashes the first error and surfaces it after the sort. */
     pub(crate) fn sort_by_lt(&self, items: &mut [Val]) -> Result<(), VmErr> {
+        let snapshot = items.to_vec();
         let mut sort_err: Option<VmErr> = None;
-        items.sort_by(|&a, &b| {
+        let order = Self::stable_sort_indices(items.len(), |a, b| {
             if sort_err.is_some() { return core::cmp::Ordering::Equal; }
-            match self.lt_vals(a, b) {
+            match self.lt_vals(snapshot[a], snapshot[b]) {
                 Ok(true) => core::cmp::Ordering::Less,
-                Ok(false) => match self.lt_vals(b, a) {
+                Ok(false) => match self.lt_vals(snapshot[b], snapshot[a]) {
                     Ok(true) => core::cmp::Ordering::Greater,
                     Ok(false) => core::cmp::Ordering::Equal,
                     Err(e) => { sort_err = Some(e); core::cmp::Ordering::Equal }
@@ -165,7 +165,41 @@ impl<'a> VM<'a> {
                 Err(e) => { sort_err = Some(e); core::cmp::Ordering::Equal }
             }
         });
-        sort_err.map_or(Ok(()), Err)
+        if let Some(e) = sort_err { return Err(e); }
+        for (dst, &src) in order.iter().enumerate() { items[dst] = snapshot[src]; }
+        Ok(())
+    }
+
+    /* Stable merge sort over `0..n`; unlike `slice::sort_by` it tolerates a non-total `cmp` (NaN keys) without aborting. */
+    fn stable_sort_indices<F>(n: usize, mut cmp: F) -> Vec<usize>
+    where F: FnMut(usize, usize) -> core::cmp::Ordering {
+        let mut idx: Vec<usize> = (0..n).collect();
+        if n < 2 { return idx; }
+        let mut buf = idx.clone();
+        let mut width = 1;
+        while width < n {
+            let mut lo = 0;
+            while lo < n {
+                let mid = (lo + width).min(n);
+                let hi = (lo + 2 * width).min(n);
+                let (mut a, mut b, mut k) = (lo, mid, lo);
+                while a < mid && b < hi {
+                    // Take the right run only on a strict Less, so equal keys keep input order (stable).
+                    if cmp(idx[b], idx[a]) == core::cmp::Ordering::Less {
+                        buf[k] = idx[b]; b += 1;
+                    } else {
+                        buf[k] = idx[a]; a += 1;
+                    }
+                    k += 1;
+                }
+                while a < mid { buf[k] = idx[a]; a += 1; k += 1; }
+                while b < hi { buf[k] = idx[b]; b += 1; k += 1; }
+                lo += 2 * width;
+            }
+            core::mem::swap(&mut idx, &mut buf);
+            width *= 2;
+        }
+        idx
     }
 
     pub fn call_reversed(&mut self) -> Result<(), VmErr> {
@@ -370,6 +404,7 @@ impl<'a> VM<'a> {
         let o = self.pop()?;
         let mut cur = self.iter_cursor(o)?;
         while let Some(v) = cur.next(&mut self.heap)? {
+            self.charge_step()?; // native iteration over a huge range must charge the op-budget
             if !self.truthy(v) {
                 self.push(Val::bool(false));
                 return Ok(());
@@ -384,6 +419,7 @@ impl<'a> VM<'a> {
         let o = self.pop()?;
         let mut cur = self.iter_cursor(o)?;
         while let Some(v) = cur.next(&mut self.heap)? {
+            self.charge_step()?; // native iteration over a huge range must charge the op-budget
             if self.truthy(v) {
                 self.push(Val::bool(true));
                 return Ok(());

--- a/compiler/src/modules/vm/handlers/data.rs
+++ b/compiler/src/modules/vm/handlers/data.rs
@@ -64,17 +64,23 @@ impl<'a> VM<'a> {
                 let v = self.pop()?;
 
                 // Conversion flags consult the dunder-aware helpers so `f"{x!s}"` honours `__str__`.
+                // Charge each result's length; a big Str is one heap object the object quota misses.
                 let converted = match conv {
-                    1 => { let s = self.repr_op(v, chunk, slots)?; self.heap.alloc(HeapObj::Str(s))? }
-                    2 => { let s = self.display_op(v, chunk, slots)?; self.heap.alloc(HeapObj::Str(s))? }
-                    3 => self.heap.alloc(HeapObj::Str(super::format::display_inline(v, &self.heap).escape_default().collect::<String>()))?,
+                    1 => { let s = self.repr_op(v, chunk, slots)?; self.charge_steps(s.len())?; self.heap.alloc(HeapObj::Str(s))? }
+                    2 => { let s = self.display_op(v, chunk, slots)?; self.charge_steps(s.len())?; self.heap.alloc(HeapObj::Str(s))? }
+                    3 => {
+                        let raw = super::format::display_inline(v, &self.heap);
+                        self.charge_steps(raw.len())?;
+                        self.heap.alloc(HeapObj::Str(raw.escape_default().collect::<String>()))?
+                    }
                     _ => v,
                 };
 
                 let result = match spec_val {
                     Some(sv) => {
-                        let spec = match self.heap.get(sv) {
-                            HeapObj::Str(s) => s.clone(),
+                        // `try_get`: a non-heap spec value is a TypeError, not a bad-index heap access.
+                        let spec = match self.heap.try_get(sv) {
+                            Some(HeapObj::Str(s)) => s.clone(),
                             _ => return Err(cold_type("format spec must be a string")),
                         };
                         // Instance `__format__(spec)` runs through `format_op`; built-ins fall through to the spec engine.

--- a/compiler/src/modules/vm/handlers/format.rs
+++ b/compiler/src/modules/vm/handlers/format.rs
@@ -12,9 +12,10 @@ pub fn format_value(v: Val, spec: &str, heap: &HeapPool) -> Result<String, &'sta
         return Ok(display_inline(v, heap));
     }
     let parsed = parse_spec(spec)?;
-    // Width and precision both drive allocation; cap them against the heap budget.
+    // Cap against the heap budget; precision also below core::fmt's u16 abort threshold (panics at >= 65535).
+    const PRECISION_MAX: usize = 65_000;
     if parsed.width > heap.limit() { return Err("format width exceeds limit"); }
-    if parsed.precision.is_some_and(|p| p > heap.limit()) { return Err("format precision exceeds limit"); }
+    if parsed.precision.is_some_and(|p| p > heap.limit().min(PRECISION_MAX)) { return Err("format precision exceeds limit"); }
     apply(v, &parsed, heap)
 }
 

--- a/compiler/src/modules/vm/helpers.rs
+++ b/compiler/src/modules/vm/helpers.rs
@@ -181,10 +181,11 @@ impl<'a> VM<'a> {
 
     /* Pick the first defined Phi source; if both are undef fall back to None. */
     pub(crate) fn exec_phi(op: u16, rip: usize, phi_map: &[usize], slots: &mut [Val], phi_sources: &[(u16, u16)]) {
-        let (ia, ib) = phi_sources[phi_map[rip]];
-        let a = slots[ia as usize];
+        // Parse recovery can leave a Phi indexing past `slots` (sized to names.len()); index defensively.
+        let Some(&(ia, ib)) = phi_map.get(rip).and_then(|&pi| phi_sources.get(pi)) else { return };
+        let a = slots.get(ia as usize).copied().unwrap_or_else(Val::undef);
         let val = if !a.is_undef() { a }
-        else { let b = slots[ib as usize]; if !b.is_undef() { b } else { Val::none() } };
-        slots[op as usize] = val;
+        else { let b = slots.get(ib as usize).copied().unwrap_or_else(Val::undef); if !b.is_undef() { b } else { Val::none() } };
+        if let Some(dst) = slots.get_mut(op as usize) { *dst = val; }
     }
 }

--- a/compiler/src/modules/vm/ops.rs
+++ b/compiler/src/modules/vm/ops.rs
@@ -9,6 +9,9 @@ use core::cell::RefCell;
 /* Cap on nested-container rendering depth; stops self-referential prints from overflowing the stack. */
 const RENDER_DEPTH_MAX: usize = 100;
 
+/* Cap on total rendered output; bounds breadth the way RENDER_DEPTH_MAX bounds depth. */
+const MAX_REPR_LEN: usize = 1_000_000;
+
 /* Same cap for `<` descent; self-referential sequences raise RecursionError. */
 const CMP_DEPTH_MAX: usize = 100;
 
@@ -174,7 +177,13 @@ impl<'a> VM<'a> {
 
     fn append_reprs<'b>(&self, out: &mut String, it: impl Iterator<Item = &'b Val>, seen: &mut Vec<u32>) {
         let mut first = true;
-        for v in it { if !first { out.push_str(", "); } out.push_str(&self.repr_d(*v, seen)); first = false; }
+        for v in it {
+            // Bound breadth: a wide structure re-referencing one big child would render without limit.
+            if out.len() > MAX_REPR_LEN { out.push_str(", ..."); break; }
+            if !first { out.push_str(", "); }
+            out.push_str(&self.repr_d(*v, seen));
+            first = false;
+        }
     }
 
     pub fn display(&self, v: Val) -> String { self.display_d(v, &mut Vec::new()) }
@@ -210,7 +219,7 @@ impl<'a> VM<'a> {
             HeapObj::Range(s,e,st) => if *st == 1 { s!("range(", int *s, ", ", int *e, ")") } else { s!("range(", int *s, ", ", int *e, ", ", int *st, ")") },
             HeapObj::List(l) => { let id = v.as_heap(); if seen.contains(&id) { return "[...]".into(); } seen.push(id); let mut o = s!(cap: 32; "["); self.append_reprs(&mut o, l.borrow().iter(), seen); o.push(']'); seen.pop(); o },
             HeapObj::Tuple(t) => { let id = v.as_heap(); if seen.contains(&id) { return "(...)".into(); } seen.push(id); let o = if t.len() == 1 { s!("(", str &self.repr_d(t[0], seen), ",)") } else { let mut o = s!(cap: 32; "("); self.append_reprs(&mut o, t.iter(), seen); o.push(')'); o }; seen.pop(); o },
-            HeapObj::Dict(d) => { let id = v.as_heap(); if seen.contains(&id) { return "{...}".into(); } seen.push(id); let mut o = s!(cap: 32; "{"); for (i,(k,val)) in d.borrow().iter().enumerate() { if i>0 { o.push_str(", "); } o.push_str(&self.repr_d(k, seen)); o.push_str(": "); o.push_str(&self.repr_d(val, seen)); } o.push('}'); seen.pop(); o },
+            HeapObj::Dict(d) => { let id = v.as_heap(); if seen.contains(&id) { return "{...}".into(); } seen.push(id); let mut o = s!(cap: 32; "{"); for (i,(k,val)) in d.borrow().iter().enumerate() { if o.len() > MAX_REPR_LEN { o.push_str(", ..."); break; } if i>0 { o.push_str(", "); } o.push_str(&self.repr_d(k, seen)); o.push_str(": "); o.push_str(&self.repr_d(val, seen)); } o.push('}'); seen.pop(); o },
             HeapObj::BoundMethod(_, id) => s!("<built-in method ", str id.name(), ">"),
             HeapObj::NativeFn(id) => s!("<built-in function ", str id.name(), ">"),
             HeapObj::Class(name, _, _) => crate::s!("<class '", str name, "'>"  ),

--- a/compiler/src/modules/vm/types/eq.rs
+++ b/compiler/src/modules/vm/types/eq.rs
@@ -30,6 +30,9 @@ fn eq_vals_depth(a: Val, b: Val, heap: &HeapPool, depth: usize) -> bool {
         return a.0 == b.0;
     }
 
+    // A heap object equals itself; short-circuits self-referential containers before the element walk.
+    if a.0 == b.0 { return true; }
+
     let d = depth + 1;
     match (heap.get(a), heap.get(b)) {
         (HeapObj::Str(x), HeapObj::Str(y)) => x == y,

--- a/compiler/tests/cases/vm.json
+++ b/compiler/tests/cases/vm.json
@@ -1831,5 +1831,9 @@
   {"src": "print([1, 2, 3, 4, 5][61::-2])", "output": ["[5, 3, 1]"]},
   {"src": "xs = [1, 2, 3, 4, 5]\nxs[61::-2] = []\nprint(xs)", "output": ["[2, 4]"]},
   {"src": "d = {}\nd.update(-1)\nprint(d)", "output": [], "error": "'int' object is not iterable"},
-  {"src": "d = {}\nd.update([1, 2])\nprint(d)", "output": [], "error": "dictionary update sequence element must have length 2"}
+  {"src": "d = {}\nd.update([1, 2])\nprint(d)", "output": [], "error": "dictionary update sequence element must have length 2"},
+  {"src": "a = [1]\na.append(a)\na.append(a)\nprint(a == a)", "output": ["True"]},
+  {"src": "print(all(range(1, 5555555555)))", "output": [], "error": "budget exceeded"},
+  {"src": "s = \"x\"\nfor k in range(2000):\n    s = f\"{s!a}{s!a}\"\nprint(len(s))", "output": [], "error": "budget exceeded"},
+  {"src": "print(f'{1.:.75342E}')", "output": [], "error": "format precision exceeds limit"}
 ]

--- a/docs/pages/reference/builtins.md
+++ b/docs/pages/reference/builtins.md
@@ -679,7 +679,7 @@ print(repr([1, "two", 3]))
 
 ### format
 
-`format(value)` -> display form. `format(value, spec)` applies the f-string spec mini-language (`[[fill]align][sign][#][0][width][,][.precision][type]`).
+`format(value)` -> display form. `format(value, spec)` applies the f-string spec mini-language (`[[fill]align][sign][#][0][width][,][.precision][type]`). Width and precision are capped (precision at 65,000); a larger value raises `ValueError` rather than allocating an oversized string.
 
 ```python
 print(format(42))

--- a/docs/pages/reference/limits-and-errors.md
+++ b/docs/pages/reference/limits-and-errors.md
@@ -130,7 +130,7 @@ Raised as `VmErr`; most catchable with `try` / `except`.
 | `Raised("TimeoutError")` | `TimeoutError` | `with_timeout` deadline expired |
 | `Raised("CancelledError")` | `CancelledError` | User-thrown cancellation |
 | `Raised("SystemExit")` | `SystemExit` | `raise SystemExit(code)`; uncaught = clean host exit with that code |
-| `CallDepth` | `RecursionError` | Past `max_calls`, or comparing self-referential containers |
+| `CallDepth` | `RecursionError` | Past `max_calls`, or comparing distinct self-referential containers (same-object `==` short-circuits to `True`) |
 | `Heap` | `MemoryError` | Past heap limit |
 | `Budget` | `RuntimeError` | Past op limit |
 | `Runtime` | `RuntimeError` | Internal invariant or unsupported |


### PR DESCRIPTION
1. exec_phi: `slots.get(i)` guards Phi index out-of-bounds
2. sorted/sort: stable merge sort tolerates NaN keys
3. all/any: charge_step bounds native range iteration
4. repr: MAX_REPR_LEN caps rendered output breadth
5. f-string conv: charge_steps bounds produced string length
6. format spec: try_get rejects non-heap spec value
7. format precision: cap below core::fmt abort threshold
8. coroutine resume: depth guard bounds mutual-await recursion
9. eq: same-object containers short-circuit to True